### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/init.zsh
+++ b/init.zsh
@@ -16,11 +16,11 @@ p6df::modules::alfred::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::alfred::external::brew()
+# Function: p6df::modules::alfred::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::alfred::external::brew() {
+p6df::modules::alfred::external::brews() {
 
   p6df::core::homebrew::cli::brew::install --cask alfred
 


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly