### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -41,5 +41,5 @@ p6df::modules::alfred::external::brews() {
 p6df::modules::alfred::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'alfred' '$ALFRED_INSTALLED'
+  p6_return_words 'alfred' "$ALFRED_INSTALLED"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -40,5 +40,6 @@ p6df::modules::alfred::external::brews() {
 ######################################################################
 p6df::modules::alfred::profile::mod() {
 
+  # shellcheck disable=SC2016
   p6_return_words 'alfred' '$ALFRED_INSTALLED'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -26,3 +26,19 @@ p6df::modules::alfred::external::brews() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words alfred = p6df::modules::alfred::profile::mod()
+#
+#  Returns:
+#	words - alfred
+#
+#  Environment:	 ALFRED_INSTALLED
+#>
+######################################################################
+p6df::modules::alfred::profile::mod() {
+
+  p6_return_words 'alfred' '$ALFRED_INSTALLED'
+}


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None